### PR TITLE
Add Eq derives where available

### DIFF
--- a/cspice/src/common.rs
+++ b/cspice/src/common.rs
@@ -6,7 +6,7 @@ pub(crate) static SET: StaticSpiceStr = static_spice_str!("SET");
 pub(crate) static GET: StaticSpiceStr = static_spice_str!("GET");
 pub(crate) static CALENDAR: StaticSpiceStr = static_spice_str!("CALENDAR");
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum ComparisonOperator {
     EQ,
     NE,
@@ -30,7 +30,7 @@ impl ComparisonOperator {
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum Side {
     Left,
     Right,
@@ -45,7 +45,7 @@ impl Side {
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[allow(non_camel_case_types)]
 pub enum AberrationCorrection {
     NONE,

--- a/cspice/src/error.rs
+++ b/cspice/src/error.rs
@@ -22,7 +22,7 @@ pub struct Error {
 }
 
 /// See [Choosing the Error Response Action](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/req/error.html#Choosing%20the%20Error%20Response%20Action).
-#[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "UPPERCASE")]
 pub enum ErrorAction {
     Abort,
@@ -33,7 +33,7 @@ pub enum ErrorAction {
 }
 
 /// See [Choosing Where the Error Messages Are Sent](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/req/error.html#Choosing%20Where%20the%20Error%20Messages%20Are%20Sent).
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ErrorDevice {
     Screen,
     Null,

--- a/cspice/src/time/calendar.rs
+++ b/cspice/src/time/calendar.rs
@@ -8,16 +8,16 @@ pub trait Calendar {
 
 /// Uses the Julian calendar for dates prior to Oct 5, 1582, and the Gregorian calendar for dates
 /// after Oct 15, 1582.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct Mixed;
 
 /// The Gregorian calendar. Dates before the Gregorian calendar's inception in 1582 are defined via
 /// extrapolation.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct Gregorian;
 
 /// The Julian calendar.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct Julian;
 
 impl Calendar for Mixed {

--- a/cspice/src/time/system.rs
+++ b/cspice/src/time/system.rs
@@ -10,15 +10,15 @@ pub trait System: Default {
 /// Terrestrial Dynamical Time (TDT).
 ///
 /// Note: TDT and TT represent the same time system
-#[derive(Copy, Clone, Debug, PartialEq, Default)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
 pub struct Tdt;
 
 /// Barycentric Dynamical Time (TDB).
-#[derive(Copy, Clone, Debug, PartialEq, Default)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
 pub struct Tdb;
 
 /// Coordinated Universal Time (UTC).
-#[derive(Copy, Clone, Debug, PartialEq, Default)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
 pub struct Utc {
     pub zone_hours: i8,
     pub zone_minutes: u8,


### PR DESCRIPTION
Fix for new clippy warnings resulting from lacking trivial `Eq` implementations, where `PartialEq` is already implemented. As discussed in #1 