### PR TITLE
Adjust SPK position and velocity return types

### DIFF
--- a/cspice/src/coordinates.rs
+++ b/cspice/src/coordinates.rs
@@ -15,6 +15,8 @@ pub struct State {
 
 impl From<[SpiceDouble; 6]> for State {
     fn from(state: [SpiceDouble; 6]) -> Self {
+        // Unsafety: This operation is safe as we're operating on owned memory,
+        // and making no unsafe type conversions.
         let (position, velocity): ([SpiceDouble; 3], [SpiceDouble; 3]) =
             unsafe { std::mem::transmute(state) };
         Self {

--- a/cspice/src/coordinates.rs
+++ b/cspice/src/coordinates.rs
@@ -1,16 +1,26 @@
 //! Functions for converting between different types of coordinates.
-use crate::spice_unsafe;
-use crate::vector::Vector3D;
+use crate::{spice_unsafe, vector::Vector3D};
 use cspice_sys::{azlrec_c, recazl_c, reclat_c, recrad_c, SpiceBoolean, SpiceDouble};
-use derive_more::{Deref, DerefMut, From, Into};
+use derive_more::{Deref, DerefMut, Into};
 
 /// Rectangular coordinates
-#[derive(Copy, Clone, Debug, Default, PartialEq, From, Into, Deref, DerefMut)]
-pub struct Rectangular(Vector3D);
+#[derive(Copy, Clone, Debug, Default, PartialEq, Into, Deref, DerefMut)]
+pub struct Rectangular(pub [SpiceDouble; 3]);
 
-impl From<[SpiceDouble; 3]> for Rectangular {
-    fn from(d: [SpiceDouble; 3]) -> Self {
-        Vector3D::from(d).into()
+#[derive(Copy, Clone, Debug, Default, PartialEq, Into)]
+pub struct State {
+    pub position: Rectangular,
+    pub velocity: Vector3D,
+}
+
+impl From<[SpiceDouble; 6]> for State {
+    fn from(state: [SpiceDouble; 6]) -> Self {
+        let (position, velocity): ([SpiceDouble; 3], [SpiceDouble; 3]) =
+            unsafe { std::mem::transmute(state) };
+        Self {
+            position: Rectangular(position),
+            velocity: Vector3D(velocity),
+        }
     }
 }
 

--- a/cspice/src/coordinates.rs
+++ b/cspice/src/coordinates.rs
@@ -1,14 +1,12 @@
 //! Functions for converting between different types of coordinates.
 use crate::spice_unsafe;
 use cspice_sys::{azlrec_c, recazl_c, reclat_c, recrad_c, SpiceBoolean, SpiceDouble};
-use derive_more::{Deref, DerefMut, Into};
+use derive_more::Into;
 
 /// Rectangular coordinates
 #[repr(C)]
-#[derive(Copy, Clone, Debug, Default, PartialEq, Into, Deref, DerefMut)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Into)]
 pub struct Rectangular {
-    #[deref]
-    #[deref_mut]
     pub x: SpiceDouble,
     pub y: SpiceDouble,
     pub z: SpiceDouble,
@@ -40,11 +38,11 @@ pub struct AzEl {
 
 impl AzEl {
     /// See [recazl_c](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/recazl_c.html)
-    pub fn from_rect(rect: Rectangular, azccw: bool, elplsz: bool) -> Self {
+    pub fn from_rect(mut rect: Rectangular, azccw: bool, elplsz: bool) -> Self {
         let mut az_el = AzEl::default();
         spice_unsafe!({
             recazl_c(
-                &*rect as *const SpiceDouble as *mut SpiceDouble,
+                &mut rect.x as *mut SpiceDouble,
                 azccw as SpiceBoolean,
                 elplsz as SpiceBoolean,
                 &mut az_el.range,
@@ -84,11 +82,11 @@ pub struct RaDec {
 
 impl From<Rectangular> for RaDec {
     /// See [recrad_c](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/recrad_c.html).
-    fn from(rect: Rectangular) -> Self {
+    fn from(mut rect: Rectangular) -> Self {
         let mut ra_dec = RaDec::default();
         spice_unsafe!({
             recrad_c(
-                &*rect as *const SpiceDouble as *mut SpiceDouble,
+                &mut rect.x as *mut SpiceDouble,
                 &mut ra_dec.range,
                 &mut ra_dec.ra,
                 &mut ra_dec.dec,
@@ -108,11 +106,11 @@ pub struct Latitudinal {
 
 impl From<Rectangular> for Latitudinal {
     /// See [reclat_c](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/reclat_c.html).
-    fn from(rect: Rectangular) -> Self {
+    fn from(mut rect: Rectangular) -> Self {
         let mut lat = Latitudinal::default();
         spice_unsafe!({
             reclat_c(
-                &*rect as *const SpiceDouble as *mut SpiceDouble,
+                &mut rect.x as *mut SpiceDouble,
                 &mut lat.radius,
                 &mut lat.longitude,
                 &mut lat.latitude,

--- a/cspice/src/spk.rs
+++ b/cspice/src/spk.rs
@@ -1,9 +1,9 @@
 //! Functions relating to the Spacecraft and Planet Ephemeris (SPK) subsystem of SPICE.
 use crate::common::AberrationCorrection;
+use crate::coordinates::{Rectangular, State};
 use crate::error::get_last_error;
 use crate::string::StringParam;
 use crate::time::Et;
-use crate::vector::Vector3D;
 use crate::{spice_unsafe, Error};
 use cspice_sys::{spkez_c, spkezp_c, spkezr_c, spkpos_c, SpiceDouble};
 
@@ -17,13 +17,13 @@ pub fn position<'t, 'r, 'o, T, R, O>(
     reference_frame: R,
     aberration_correction: AberrationCorrection,
     observing_body: O,
-) -> Result<(Vector3D, SpiceDouble), Error>
+) -> Result<(Rectangular, SpiceDouble), Error>
 where
     T: Into<StringParam<'t>>,
     R: Into<StringParam<'r>>,
     O: Into<StringParam<'o>>,
 {
-    let mut position = Vector3D::default();
+    let mut position = Rectangular::default();
     let mut light_time = 0.0;
     spice_unsafe!({
         spkpos_c(
@@ -51,11 +51,11 @@ pub fn easy_reader<'r, R>(
     reference_frame: R,
     aberration_correction: AberrationCorrection,
     observing_body: i32,
-) -> Result<([SpiceDouble; 6], SpiceDouble), Error>
+) -> Result<(State, SpiceDouble), Error>
 where
     R: Into<StringParam<'r>>,
 {
-    let mut pos_vel = [0.0f64; 6];
+    let mut pos_vel: [SpiceDouble; 6] = [0.0; 6];
     let mut light_time = 0.0;
     spice_unsafe!({
         spkez_c(
@@ -69,7 +69,7 @@ where
         )
     });
     get_last_error()?;
-    Ok((pos_vel, light_time))
+    Ok((State::from(pos_vel), light_time))
 }
 
 /// Return the position of a target body relative to an observing
@@ -83,11 +83,11 @@ pub fn easy_position<'r, R>(
     reference_frame: R,
     aberration_correction: AberrationCorrection,
     observing_body: i32,
-) -> Result<(Vector3D, SpiceDouble), Error>
+) -> Result<(Rectangular, SpiceDouble), Error>
 where
     R: Into<StringParam<'r>>,
 {
-    let mut position = Vector3D::default();
+    let mut position = Rectangular::default();
     let mut light_time = 0.0;
     spice_unsafe!({
         spkezp_c(
@@ -115,7 +115,7 @@ pub fn easier_reader<'t, 'r, 'o, T, R, O>(
     reference_frame: R,
     aberration_correction: AberrationCorrection,
     observing_body: O,
-) -> Result<([SpiceDouble; 6], SpiceDouble), Error>
+) -> Result<(State, SpiceDouble), Error>
 where
     T: Into<StringParam<'t>>,
     R: Into<StringParam<'r>>,
@@ -135,7 +135,7 @@ where
         )
     });
     get_last_error()?;
-    Ok((pos_vel, light_time))
+    Ok((State::from(pos_vel), light_time))
 }
 
 #[cfg(test)]
@@ -145,46 +145,53 @@ mod tests {
     const EPSILON: f64 = 1e-10;
     const ETS: [Et; 3] = [Et(0.0), Et(3600.0), Et(120000.0)];
     // Test data generated via spiceypy using the above ephemeris times
-    const TEST_DATA: [[SpiceDouble; 6]; 3] = [
-        [
-            -291569.26474221050739f64,
-            -266709.18712562322617f64,
-            -76099.15410456061363f64,
-            0.64353061379157f64,
-            -0.66608181544709f64,
-            -0.30132283179347f64,
-        ],
-        [
-            -289240.78060919046402f64,
-            -269096.44152130186558f64,
-            -77180.89871158450842f64,
-            0.65006211575479f64,
-            -0.66016273764220f64,
-            -0.29964267392589f64,
-        ],
-        [
-            -202558.33919326588511f64,
-            -333880.37279736995697f64,
-            -108450.58380541205406f64,
-            0.82840534359059f64,
-            -0.44612163419131f64,
-            -0.23419745913028f64,
-        ],
-    ];
     const LTS: [SpiceDouble; 3] = [
         1.3423106094958182f64,
         1.342693954033622f64,
         1.3519329044685606f64,
     ];
 
+    fn gen_test_data() -> [State; 3] {
+        [
+            [
+                -291569.26474221050739f64,
+                -266709.18712562322617f64,
+                -76099.15410456061363f64,
+                0.64353061379157f64,
+                -0.66608181544709f64,
+                -0.30132283179347f64,
+            ]
+            .into(),
+            [
+                -289240.78060919046402f64,
+                -269096.44152130186558f64,
+                -77180.89871158450842f64,
+                0.65006211575479f64,
+                -0.66016273764220f64,
+                -0.29964267392589f64,
+            ]
+            .into(),
+            [
+                -202558.33919326588511f64,
+                -333880.37279736995697f64,
+                -108450.58380541205406f64,
+                0.82840534359059f64,
+                -0.44612163419131f64,
+                -0.23419745913028f64,
+            ]
+            .into(),
+        ]
+    }
+
     #[test]
     fn moon_earth_spkpos_test() {
         load_test_data();
+        let test_data = gen_test_data();
         for i in 0..3 {
             let (pos, lt) =
                 position("moon", ETS[i], "J2000", AberrationCorrection::LT, "earth").unwrap();
             for j in 0..3 {
-                assert!((pos[j] - TEST_DATA[i][j]).abs() < EPSILON);
+                assert!((pos[j] - test_data[i].position[j]).abs() < EPSILON);
             }
             assert!((lt - LTS[i]).abs() < EPSILON);
         }
@@ -193,11 +200,13 @@ mod tests {
     #[test]
     fn moon_earth_spkez_test() {
         load_test_data();
+        let test_data = gen_test_data();
         for i in 0..3 {
-            let (pos_vel, lt) =
+            let (state, lt) =
                 easy_reader(301, ETS[i], "J2000", AberrationCorrection::LT, 399).unwrap();
-            for j in 0..6 {
-                assert!((pos_vel[j] - TEST_DATA[i][j]).abs() < EPSILON);
+            for j in 0..3 {
+                assert!((state.position[j] - test_data[i].position[j]).abs() < EPSILON);
+                assert!((state.velocity[j] - test_data[i].velocity[j]).abs() < EPSILON);
             }
             assert!((lt - LTS[i]).abs() < EPSILON);
         }
@@ -206,11 +215,12 @@ mod tests {
     #[test]
     fn moon_earth_spkezp_test() {
         load_test_data();
+        let test_data = gen_test_data();
         for i in 0..3 {
             let (pos, lt) =
                 easy_position(301, ETS[i], "J2000", AberrationCorrection::LT, 399).unwrap();
             for j in 0..3 {
-                assert!((pos[j] - TEST_DATA[i][j]).abs() < EPSILON);
+                assert!((pos[j] - test_data[i].position[j]).abs() < EPSILON);
             }
             assert!((lt - LTS[i]).abs() < EPSILON);
         }
@@ -219,11 +229,13 @@ mod tests {
     #[test]
     fn moon_earth_spkezr_test() {
         load_test_data();
+        let test_data = gen_test_data();
         for i in 0..3 {
-            let (pos_vel, lt) =
+            let (state, lt) =
                 easier_reader("moon", ETS[i], "J2000", AberrationCorrection::LT, "earth").unwrap();
-            for j in 0..6 {
-                assert!((pos_vel[j] - TEST_DATA[i][j]).abs() < EPSILON);
+            for j in 0..3 {
+                assert!((state.position[j] - test_data[i].position[j]).abs() < EPSILON);
+                assert!((state.velocity[j] - test_data[i].velocity[j]).abs() < EPSILON);
             }
             assert!((lt - LTS[i]).abs() < EPSILON);
         }

--- a/cspice/src/spk.rs
+++ b/cspice/src/spk.rs
@@ -144,13 +144,13 @@ mod tests {
     use crate::tests::load_test_data;
     const EPSILON: f64 = 1e-10;
     const ETS: [Et; 3] = [Et(0.0), Et(3600.0), Et(120000.0)];
-    // Test data generated via spiceypy using the above ephemeris times
     const LTS: [SpiceDouble; 3] = [
         1.3423106094958182f64,
         1.342693954033622f64,
         1.3519329044685606f64,
     ];
 
+    // Test data generated via spiceypy using the above ephemeris times
     fn gen_test_data() -> [State; 3] {
         [
             [

--- a/cspice/src/vector.rs
+++ b/cspice/src/vector.rs
@@ -7,7 +7,7 @@ use derive_more::{Deref, DerefMut, From, Into};
 
 /// A 3D vector
 #[derive(Copy, Clone, Debug, Default, PartialEq, From, Into, Deref, DerefMut)]
-pub struct Vector3D([SpiceDouble; 3]);
+pub struct Vector3D(pub [SpiceDouble; 3]);
 
 impl Vector3D {
     /// Find the separation angle in radians between two double precision, 3-dimensional vectors.

--- a/cspice/src/vector.rs
+++ b/cspice/src/vector.rs
@@ -1,6 +1,7 @@
 //! Functions for working with 3D Vectors.
 //!
 //! See [Performing simple operations on 3D vectors](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/info/mostused.html#U)
+use crate::coordinates::Rectangular;
 use crate::spice_unsafe;
 use cspice_sys::{vsep_c, SpiceDouble};
 use derive_more::{Deref, DerefMut, From, Into};
@@ -21,5 +22,11 @@ impl Vector3D {
                 other.as_ptr() as *mut SpiceDouble,
             )
         })
+    }
+}
+
+impl From<Rectangular> for Vector3D {
+    fn from(rect: Rectangular) -> Self {
+        Self([rect.x, rect.y, rect.z])
     }
 }


### PR DESCRIPTION
Addresses #4 changing the return types of SPK functions to return position as `Rectangular` rather than `[SpiceDouble; 3]`

Also creates a new struct `State` when functions return position and velocity.

```rust
pub struct State {
    pub position: Rectangular,
    pub velocity: Vector3D,
}
```

`State` also implements `From<[SpiceDouble; 6]>` to quickly convert.