### PR TITLE
Automatically download CSPICE on build if it is not located

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,11 +13,12 @@ jobs:
       run:
         shell: ${{ matrix.SHELL }}
     env:
-      CSPICE_DIR: '${{ github.workspace }}/cspice'
+      CSPICE_DIR: ${{ matrix.CSPICE_DIR }}
       CSPICE_URL: ${{ matrix.CSPICE_URL }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        download_cspice: [true, false]
         include:
           - os: ubuntu-latest
             CSPICE_URL: "https://naif.jpl.nasa.gov/pub/naif/toolkit//C/PC_Linux_GCC_64bit/packages/cspice.tar.Z"
@@ -28,27 +29,30 @@ jobs:
           - os: windows-latest
             CSPICE_URL: "https://naif.jpl.nasa.gov/pub/naif/toolkit//C/PC_Windows_VisualC_64bit/packages/cspice.zip"
             SHELL: powershell
+          - download_cspice: false
+            CSPICE_DIR: '${{ github.workspace }}/cspice'
+
     steps:
       - uses: actions/checkout@v2
 
       - name: Download CSPICE
-        if: ${{ matrix.os != 'windows-latest' }}
+        if: ${{ matrix.os != 'windows-latest' && matrix.download_cspice }}
         run: wget ${{ matrix.CSPICE_URL }}
 
       - name: Download CSPICE (Windows)
-        if: ${{ matrix.os == 'windows-latest' }}
+        if: ${{ matrix.os == 'windows-latest' && matrix.download_cspice }}
         run: wget ${{ matrix.CSPICE_URL }} -outfile cspice.zip
 
       - name: Extract CSPICE
-        if: ${{ matrix.os != 'windows-latest' }}
+        if: ${{ matrix.os != 'windows-latest' && matrix.download_cspice }}
         run: tar -zxvf "${CSPICE_URL##*/}"
 
       - name: Extract CSPICE (Windows)
-        if: ${{ matrix.os == 'windows-latest' }}
+        if: ${{ matrix.os == 'windows-latest' && matrix.download_cspice }}
         run: tar -xf cspice.zip
 
       - name: Fix libcspice name
-        if: ${{ matrix.os != 'windows-latest' }}
+        if: ${{ matrix.os != 'windows-latest' && matrix.download_cspice }}
         run: mv $CSPICE_DIR/lib/cspice.a $CSPICE_DIR/lib/libcspice.a
 
       - name: Cargo Test
@@ -56,20 +60,6 @@ jobs:
 
       - name: Cargo Clippy Check
         run: cargo clippy --workspace -- -D warnings
-
-  build_with_download:
-    runs-on: ${{ matrix.os }}
-    defaults:
-      run:
-        shell: ${{ matrix.SHELL }}
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Cargo Test
-        run: cargo test --features downloadcspice -- --nocapture --test-threads=1
-
-      - name: Cargo Clippy Check
-        run: cargo clippy --features downloadcspice --workspace -- -D warnings
 
   check_style:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,12 +13,11 @@ jobs:
       run:
         shell: ${{ matrix.SHELL }}
     env:
-      CSPICE_DIR: ${{ matrix.CSPICE_DIR }}
+      CSPICE_DIR: '${{ github.workspace }}/cspice'
       CSPICE_URL: ${{ matrix.CSPICE_URL }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        download_cspice: [true, false]
         include:
           - os: ubuntu-latest
             CSPICE_URL: "https://naif.jpl.nasa.gov/pub/naif/toolkit//C/PC_Linux_GCC_64bit/packages/cspice.tar.Z"
@@ -29,30 +28,28 @@ jobs:
           - os: windows-latest
             CSPICE_URL: "https://naif.jpl.nasa.gov/pub/naif/toolkit//C/PC_Windows_VisualC_64bit/packages/cspice.zip"
             SHELL: powershell
-          - download_cspice: false
-            CSPICE_DIR: '${{ github.workspace }}/cspice'
 
     steps:
       - uses: actions/checkout@v2
 
       - name: Download CSPICE
-        if: ${{ matrix.os != 'windows-latest' && matrix.download_cspice }}
+        if: ${{ matrix.os != 'windows-latest' }}
         run: wget ${{ matrix.CSPICE_URL }}
 
       - name: Download CSPICE (Windows)
-        if: ${{ matrix.os == 'windows-latest' && matrix.download_cspice }}
+        if: ${{ matrix.os == 'windows-latest' }}
         run: wget ${{ matrix.CSPICE_URL }} -outfile cspice.zip
 
       - name: Extract CSPICE
-        if: ${{ matrix.os != 'windows-latest' && matrix.download_cspice }}
+        if: ${{ matrix.os != 'windows-latest' }}
         run: tar -zxvf "${CSPICE_URL##*/}"
 
       - name: Extract CSPICE (Windows)
-        if: ${{ matrix.os == 'windows-latest' && matrix.download_cspice }}
+        if: ${{ matrix.os == 'windows-latest' }}
         run: tar -xf cspice.zip
 
       - name: Fix libcspice name
-        if: ${{ matrix.os != 'windows-latest' && matrix.download_cspice }}
+        if: ${{ matrix.os != 'windows-latest' }}
         run: mv $CSPICE_DIR/lib/cspice.a $CSPICE_DIR/lib/libcspice.a
 
       - name: Cargo Test
@@ -60,6 +57,20 @@ jobs:
 
       - name: Cargo Clippy Check
         run: cargo clippy --workspace -- -D warnings
+
+  build_with_auto_download:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Cargo Test
+        run: cargo test --features downloadcspice -- --nocapture --test-threads=1
+
+      - name: Cargo Clippy Check
+        run: cargo clippy --features downloadcspice --workspace -- -D warnings
 
   check_style:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -52,11 +52,24 @@ jobs:
         run: mv $CSPICE_DIR/lib/cspice.a $CSPICE_DIR/lib/libcspice.a
 
       - name: Cargo Test
-        run: cargo test --all-features -- --nocapture --test-threads=1
+        run: cargo test -- --nocapture --test-threads=1
 
       - name: Cargo Clippy Check
-        run: cargo clippy --all-features --workspace -- -D warnings
+        run: cargo clippy --workspace -- -D warnings
 
+  build_with_download:
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: ${{ matrix.SHELL }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Cargo Test
+        run: cargo test --features downloadcspice -- --nocapture --test-threads=1
+
+      - name: Cargo Clippy Check
+        run: cargo clippy --features downloadcspice --workspace -- -D warnings
 
   check_style:
     runs-on: ubuntu-latest

--- a/cspice-sys/Cargo.toml
+++ b/cspice-sys/Cargo.toml
@@ -9,8 +9,11 @@ authors = ["Jacob Halsey <jacob@jhalsey.com>"]
 homepage = "https://github.com/jacob-pro/cspice-rs/tree/master/cspice-sys"
 repository = "https://github.com/jacob-pro/cspice-rs"
 
+[features]
+downloadcspice = ["dep:reqwest"]
+
 [dependencies]
 
 [build-dependencies]
 bindgen = "0.60.1"
-reqwest = { version = "0.11.12", features = ["blocking"] }
+reqwest = { version = "0.11.12", features = ["blocking"], optional = true }

--- a/cspice-sys/Cargo.toml
+++ b/cspice-sys/Cargo.toml
@@ -13,3 +13,4 @@ repository = "https://github.com/jacob-pro/cspice-rs"
 
 [build-dependencies]
 bindgen = "0.60.1"
+reqwest = { version = "0.11.12", features = ["blocking"] }

--- a/cspice-sys/README.md
+++ b/cspice-sys/README.md
@@ -12,17 +12,24 @@ Read the [official CSPICE documentation online](https://naif.jpl.nasa.gov/pub/na
 
 ## Installation
 
-You must first have installed the CSPICE toolkit by downloading and extracting the appropriate archive from 
+Firstly, you must have [Clang](https://releases.llvm.org/download.html) installed and on your `PATH` to be able to generate 
+the bindings.
+
+If you're on a Unix-like system and have CSPICE installed in the standard paths (`libcspice.a` in `/usr/lib` and headers in `/usr/include`),
+that version will be used by default.
+
+Alternatively, you can enable the `downloadcspice` feature on the crate to automatically download CSPICE from NAIF servers
+when this crate is built. Be aware that this will increase build time and require an internet connection on every clean build.
+
+You can also download CSPICE and tell this crate about where to find it manually:
+First install the CSPICE toolkit by downloading and extracting the appropriate archive from 
 [here](https://naif.jpl.nasa.gov/naif/toolkit_C.html).
 
-You must set the `CSPICE_DIR` environment variable to point to the extracted `cspice` directory (which should contain
+Then, set the `CSPICE_DIR` environment variable to point to the extracted `cspice` directory (which should contain
 the `include` and `lib` directories).
 
 **WARNING**: On Unix like systems you will likely need to rename `lib/cspice.a` to `lib/libcspice.a` so that it can be
 successfully linked.
-
-You must have [Clang](https://releases.llvm.org/download.html) installed and on your `PATH` to be able to generate 
-the bindings. 
 
 Also see the [GitHub workflow](../.github/workflows/rust.yml) for examples on how to set this up.
 

--- a/cspice-sys/build.rs
+++ b/cspice-sys/build.rs
@@ -81,9 +81,10 @@ fn main() {
 
 // Check for CSPICE installation in system library folders
 fn locate_cspice() -> Option<PathBuf> {
-    // TODO: Check alternate install paths and other platforms
     match env::consts::OS {
-        "linux" if Path::new("/usr/lib/libcspice.a").exists() => Some(PathBuf::from("/usr")),
+        "linux" | "macos" if Path::new("/usr/lib/libcspice.a").exists() => {
+            Some(PathBuf::from("/usr"))
+        }
         _ => None,
     }
 }
@@ -92,8 +93,15 @@ fn locate_cspice() -> Option<PathBuf> {
 fn download_cspice(out_dir: &Path) {
     let (platform, extension) = match env::consts::OS {
         "linux" => ("PC_Linux_GCC_64bit", "tar.Z"),
-        "macos" => ("MacM1_OSX_clang_64bit", "tar.Z"), // UNTESTED
-        "windows" => ("PC_Windows_VisualC_64bit", "zip"), // UNTESTED
+        "macos" => (
+            if cfg!(target_arch = "arm") {
+                "MacM1_OSX_clang_64bit"
+            } else {
+                "MacIntel_OSX_AppleC_64bit"
+            },
+            "tar.Z",
+        ),
+        "windows" => ("PC_Windows_VisualC_64bit", "zip"),
         _ => {
             unimplemented!("Cannot fetch CSPICE source for this platform, please download manually")
         }


### PR DESCRIPTION
Hello Jacob!
Thank you for your work on this library!
This PR modifies the `cspice-sys` build script to, when `CSPICE_DIR` isn't set, search the system library path and then, if that's unsuccessful, download CSPICE directly from NAIF servers. This does increase build time on the first build and also adds a build dependency on `reqwest`, however, I think the ergonomic improvement is more than worth it. If you do not consider this behavior desirable by default, it could easily be locked behind a feature flag.

I tested this on Arch Linux and a fresh install of Windows 10 with only Git Bash + Unix tools, LLVM and Rust installed. I *think* this should work on M1 and Intel Macs as well, I took care to handle them in the code, but unfortunately I can't test that as I do not own a Mac. Perhaps you could help with that?

The code is written to easily have new platforms/archive file types added, there are a couple more on [the NAIF page](https://naif.jpl.nasa.gov/naif/toolkit_C.html), but I think the major ones are covered here. Of course, there may be issues I didn't run into with my limited testing.

Feel free to request any changes you deem appropriate, I have some free time at the moment.

Cheers, have a nice day! :)