### PR TITLE
Release cspice-sys 1.0.4, allow cspice usage from different threads

### DIFF
--- a/cspice-sys/Cargo.toml
+++ b/cspice-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cspice-sys"
-version = "1.0.3"
+version = "1.0.4"
 edition = "2021"
 build = "build.rs"
 description = "Unsafe bindings to the NAIF CSPICE toolkit"

--- a/cspice-sys/build.rs
+++ b/cspice-sys/build.rs
@@ -122,17 +122,17 @@ fn download_cspice(out_dir: &Path) {
     match (env::consts::OS, extension) {
         ("linux" | "macos", "tar.Z") => {
             Command::new("gzip")
-                .current_dir(&out_dir)
+                .current_dir(out_dir)
                 .args(["-d", "cspice.tar.Z"])
                 .status()
                 .expect("Failed to extract with gzip");
             Command::new("tar")
-                .current_dir(&out_dir)
+                .current_dir(out_dir)
                 .args(["xf", "cspice.tar"])
                 .status()
                 .expect("Failed to extract with tar");
 
-            std::fs::rename(
+            fs::rename(
                 out_dir.join("cspice/lib/cspice.a"),
                 out_dir.join("cspice/lib/libcspice.a"),
             )
@@ -140,7 +140,7 @@ fn download_cspice(out_dir: &Path) {
         }
         ("windows", "zip") => {
             Command::new("tar")
-                .current_dir(&out_dir)
+                .current_dir(out_dir)
                 .args(["xf", "cspice.zip"])
                 .status()
                 .expect("Failed to extract with tar");

--- a/cspice/Cargo.toml
+++ b/cspice/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cspice"
-version = "0.0.1"
+version = "0.1.0"
 edition = "2021"
 description = "Safe wrapper around the NAIF CSPICE toolkit"
 license = "LGPL-3.0"
@@ -10,9 +10,9 @@ repository = "https://github.com/jacob-pro/cspice-rs"
 
 [dependencies]
 chrono = { version = "0.4.19", optional = true }
-cspice-sys = { path = "../cspice-sys", version = "1.0.3" }
+cspice-sys = { path = "../cspice-sys", version = "1.0.4" }
 derive_more = "0.99.17"
-once_cell = "1.12.0"
+parking_lot = "0.12.1"
 serde = { version = "1.0.137", features = ["derive"] }
 serde_plain = "1.0.0"
 thiserror = "1.0.31"

--- a/cspice/src/data.rs
+++ b/cspice/src/data.rs
@@ -1,27 +1,31 @@
 //! Functions for loading and unloading SPICE Kernels.
 use crate::error::get_last_error;
 use crate::string::StringParam;
-use crate::{spice_unsafe, Error};
+use crate::{with_spice_lock_or_panic, Error};
 use cspice_sys::{furnsh_c, unload_c};
 
 /// Load one or more SPICE kernels into a program.
 ///
 /// See [furnsh_c](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/furnsh_c.html).
 pub fn furnish<'f, F: Into<StringParam<'f>>>(file: F) -> Result<(), Error> {
-    spice_unsafe!({
-        furnsh_c(file.into().as_mut_ptr());
-    });
-    get_last_error()
+    with_spice_lock_or_panic(|| {
+        unsafe {
+            furnsh_c(file.into().as_mut_ptr());
+        };
+        get_last_error()
+    })
 }
 
 /// Unload a SPICE kernel.
 ///
 /// See [unload_c](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/unload_c.html).
 pub fn unload<'f, F: Into<StringParam<'f>>>(file: F) -> Result<(), Error> {
-    spice_unsafe!({
-        unload_c(file.into().as_mut_ptr());
-    });
-    get_last_error()
+    with_spice_lock_or_panic(|| {
+        unsafe {
+            unload_c(file.into().as_mut_ptr());
+        };
+        get_last_error()
+    })
 }
 
 #[cfg(test)]

--- a/cspice/src/spk.rs
+++ b/cspice/src/spk.rs
@@ -5,7 +5,7 @@ use crate::error::get_last_error;
 use crate::string::StringParam;
 use crate::time::Et;
 use crate::vector::Vector3D;
-use crate::{spice_unsafe, Error};
+use crate::{with_spice_lock_or_panic, Error};
 use cspice_sys::{spkez_c, spkezp_c, spkezr_c, spkpos_c, SpiceDouble};
 use derive_more::Into;
 
@@ -42,21 +42,23 @@ where
     R: Into<StringParam<'r>>,
     O: Into<StringParam<'o>>,
 {
-    let mut position = [0.0f64; 3];
-    let mut light_time = 0.0;
-    spice_unsafe!({
-        spkpos_c(
-            target.into().as_mut_ptr(),
-            et.0,
-            reference_frame.into().as_mut_ptr(),
-            aberration_correction.as_spice_char(),
-            observing_body.into().as_mut_ptr(),
-            position.as_mut_ptr(),
-            &mut light_time,
-        )
-    });
-    get_last_error()?;
-    Ok((position.into(), light_time))
+    with_spice_lock_or_panic(|| {
+        let mut position = [0.0f64; 3];
+        let mut light_time = 0.0;
+        unsafe {
+            spkpos_c(
+                target.into().as_mut_ptr(),
+                et.0,
+                reference_frame.into().as_mut_ptr(),
+                aberration_correction.as_spice_char(),
+                observing_body.into().as_mut_ptr(),
+                position.as_mut_ptr(),
+                &mut light_time,
+            )
+        };
+        get_last_error()?;
+        Ok((position.into(), light_time))
+    })
 }
 
 /// Return the state (position and velocity) of a target body
@@ -74,21 +76,23 @@ pub fn easy_reader<'r, R>(
 where
     R: Into<StringParam<'r>>,
 {
-    let mut pos_vel: [SpiceDouble; 6] = [0.0; 6];
-    let mut light_time = 0.0;
-    spice_unsafe!({
-        spkez_c(
-            target,
-            et.0,
-            reference_frame.into().as_mut_ptr(),
-            aberration_correction.as_spice_char(),
-            observing_body,
-            pos_vel.as_mut_ptr(),
-            &mut light_time,
-        )
-    });
-    get_last_error()?;
-    Ok((State::from(pos_vel), light_time))
+    with_spice_lock_or_panic(|| {
+        let mut pos_vel: [SpiceDouble; 6] = [0.0; 6];
+        let mut light_time = 0.0;
+        unsafe {
+            spkez_c(
+                target,
+                et.0,
+                reference_frame.into().as_mut_ptr(),
+                aberration_correction.as_spice_char(),
+                observing_body,
+                pos_vel.as_mut_ptr(),
+                &mut light_time,
+            )
+        };
+        get_last_error()?;
+        Ok((State::from(pos_vel), light_time))
+    })
 }
 
 /// Return the position of a target body relative to an observing
@@ -106,21 +110,23 @@ pub fn easy_position<'r, R>(
 where
     R: Into<StringParam<'r>>,
 {
-    let mut position = [0.0f64; 3];
-    let mut light_time = 0.0;
-    spice_unsafe!({
-        spkezp_c(
-            target,
-            et.0,
-            reference_frame.into().as_mut_ptr(),
-            aberration_correction.as_spice_char(),
-            observing_body,
-            position.as_mut_ptr(),
-            &mut light_time,
-        )
-    });
-    get_last_error()?;
-    Ok((position.into(), light_time))
+    with_spice_lock_or_panic(|| {
+        let mut position = [0.0f64; 3];
+        let mut light_time = 0.0;
+        unsafe {
+            spkezp_c(
+                target,
+                et.0,
+                reference_frame.into().as_mut_ptr(),
+                aberration_correction.as_spice_char(),
+                observing_body,
+                position.as_mut_ptr(),
+                &mut light_time,
+            )
+        };
+        get_last_error()?;
+        Ok((position.into(), light_time))
+    })
 }
 
 /// Return the state (position and velocity) of a target body
@@ -140,21 +146,23 @@ where
     R: Into<StringParam<'r>>,
     O: Into<StringParam<'o>>,
 {
-    let mut pos_vel = [0.0f64; 6];
-    let mut light_time = 0.0;
-    spice_unsafe!({
-        spkezr_c(
-            target.into().as_mut_ptr(),
-            et.0,
-            reference_frame.into().as_mut_ptr(),
-            aberration_correction.as_spice_char(),
-            observing_body.into().as_mut_ptr(),
-            pos_vel.as_mut_ptr(),
-            &mut light_time,
-        )
-    });
-    get_last_error()?;
-    Ok((State::from(pos_vel), light_time))
+    with_spice_lock_or_panic(|| {
+        let mut pos_vel = [0.0f64; 6];
+        let mut light_time = 0.0;
+        unsafe {
+            spkezr_c(
+                target.into().as_mut_ptr(),
+                et.0,
+                reference_frame.into().as_mut_ptr(),
+                aberration_correction.as_spice_char(),
+                observing_body.into().as_mut_ptr(),
+                pos_vel.as_mut_ptr(),
+                &mut light_time,
+            )
+        };
+        get_last_error()?;
+        Ok((State::from(pos_vel), light_time))
+    })
 }
 
 #[cfg(test)]

--- a/cspice/src/string.rs
+++ b/cspice/src/string.rs
@@ -22,7 +22,7 @@ impl Debug for SpiceString {
 
 impl Display for SpiceString {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&*self.as_str())
+        f.write_str(&self.as_str())
     }
 }
 
@@ -117,7 +117,7 @@ impl Debug for SpiceStr<'_> {
 
 impl Display for SpiceStr<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&*self.as_str())
+        f.write_str(&self.as_str())
     }
 }
 

--- a/cspice/src/vector.rs
+++ b/cspice/src/vector.rs
@@ -2,7 +2,7 @@
 //!
 //! See [Performing simple operations on 3D vectors](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/info/mostused.html#U)
 use crate::coordinates::Rectangular;
-use crate::spice_unsafe;
+use crate::with_spice_lock_or_panic;
 use cspice_sys::{vsep_c, SpiceDouble};
 use derive_more::{Deref, DerefMut, From, Into};
 
@@ -16,7 +16,7 @@ impl Vector3D {
     ///
     /// See [vsep_c](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/vsep_c.html)
     pub fn separation_angle(&self, other: &Vector3D) -> SpiceDouble {
-        spice_unsafe!({
+        with_spice_lock_or_panic(|| unsafe {
             vsep_c(
                 self.as_ptr() as *mut SpiceDouble,
                 other.as_ptr() as *mut SpiceDouble,


### PR DESCRIPTION
- Updates the latest `cspice-sys` crate version, preparing for release containing @mclrc's changes.
- Reworks the thread safety in `cspice` to ensure that tests can be run from different threads following change in Rust compiler - https://github.com/rust-lang/rust/issues/104053
