### PR TITLE
Fix CSPICE download timeouts using read_timeout instead of overall timeout

### DIFF
--- a/cspice-sys/Cargo.toml
+++ b/cspice-sys/Cargo.toml
@@ -10,11 +10,12 @@ homepage = "https://github.com/jacob-pro/cspice-rs/tree/master/cspice-sys"
 repository = "https://github.com/jacob-pro/cspice-rs"
 
 [features]
-downloadcspice = ["dep:reqwest"]
-no-timeout = []
+downloadcspice = ["dep:reqwest", "dep:tokio", "dep:futures-util"]
 
 [dependencies]
 
 [build-dependencies]
 bindgen = "0.60.1"
-reqwest = { version = "0.11.12", features = ["blocking"], optional = true }
+reqwest = { version = "0.12.22", features = ["blocking", "stream"], optional = true }
+tokio = { version = "1", features = ["rt", "macros"], optional = true }
+futures-util = { version = "0.3", optional = true }

--- a/cspice-sys/Cargo.toml
+++ b/cspice-sys/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/jacob-pro/cspice-rs"
 
 [features]
 downloadcspice = ["dep:reqwest"]
+no-timeout = []
 
 [dependencies]
 

--- a/cspice-sys/Cargo.toml
+++ b/cspice-sys/Cargo.toml
@@ -10,12 +10,10 @@ homepage = "https://github.com/jacob-pro/cspice-rs/tree/master/cspice-sys"
 repository = "https://github.com/jacob-pro/cspice-rs"
 
 [features]
-downloadcspice = ["dep:reqwest", "dep:tokio", "dep:futures-util"]
+downloadcspice = ["dep:ureq"]
 
 [dependencies]
 
 [build-dependencies]
 bindgen = "0.60.1"
-reqwest = { version = "0.12.22", features = ["blocking", "stream"], optional = true }
-tokio = { version = "1", features = ["rt", "macros"], optional = true }
-futures-util = { version = "0.3", optional = true }
+ureq = { version = "2.10", optional = true }

--- a/cspice-sys/build.rs
+++ b/cspice-sys/build.rs
@@ -115,7 +115,7 @@ fn download_cspice(out_dir: &Path) {
     #[cfg(feature = "no-timeout")]
     let body = {
         let client = reqwest::blocking::Client::builder()
-            .timeout(None)  // disable timeout
+            .timeout(None) // disable timeout
             .build()
             .expect("Failed to build HTTP client");
 

--- a/cspice-sys/build.rs
+++ b/cspice-sys/build.rs
@@ -112,10 +112,27 @@ fn download_cspice(out_dir: &Path) {
 
     let download_target = out_dir.join(format!("cspice.{}", extension));
 
+    #[cfg(feature = "no-timeout")]
+    let body = {
+        let client = reqwest::blocking::Client::builder()
+            .timeout(None)  // disable timeout
+            .build()
+            .expect("Failed to build HTTP client");
+
+        client
+            .get(&url)
+            .send()
+            .expect("Failed to download CSPICE")
+            .bytes()
+            .unwrap()
+    };
+
+    #[cfg(not(feature = "no-timeout"))]
     let body = reqwest::blocking::get(url)
         .expect("Failed to download CSPICE")
         .bytes()
         .unwrap();
+
     std::fs::write(download_target, body).expect("Failed to write archive file");
 
     // Extract package based on platform

--- a/cspice-sys/build.rs
+++ b/cspice-sys/build.rs
@@ -112,28 +112,18 @@ fn download_cspice(out_dir: &Path) {
 
     let download_target = out_dir.join(format!("cspice.{}", extension));
 
-    #[cfg(feature = "no-timeout")]
-    let body = {
-        let client = reqwest::blocking::Client::builder()
-            .timeout(None) // disable timeout
-            .build()
-            .expect("Failed to build HTTP client");
+    println!("Downloading from: {}", url);
 
-        client
-            .get(&url)
-            .send()
-            .expect("Failed to download CSPICE")
-            .bytes()
-            .unwrap()
-    };
+    // Tokioランタイムを作成して非同期ダウンロードを実行
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("Failed to create tokio runtime");
 
-    #[cfg(not(feature = "no-timeout"))]
-    let body = reqwest::blocking::get(url)
-        .expect("Failed to download CSPICE")
-        .bytes()
-        .unwrap();
+    let downloaded_bytes =
+        rt.block_on(async { download_cspice_async(&url, &download_target).await });
 
-    std::fs::write(download_target, body).expect("Failed to write archive file");
+    println!("Download complete: {} bytes", downloaded_bytes);
 
     // Extract package based on platform
     match (env::consts::OS, extension) {
@@ -185,4 +175,97 @@ fn docs_rs(out_dir: &Path) {
         .expect("Unable to call tar");
     assert!(tar_status.success());
     env::set_var("CSPICE_DIR", headers_dir.as_os_str());
+}
+
+// Asynchronous download implementation
+#[cfg(feature = "downloadcspice")]
+async fn download_cspice_async(url: &str, download_target: &PathBuf) -> u64 {
+    use futures_util::StreamExt;
+    use std::io::Write;
+
+    // HTTP client configuration
+    let client = reqwest::Client::builder()
+        // Connection timeout: 30 seconds
+        .connect_timeout(std::time::Duration::from_secs(30))
+        // Read timeout: 60 seconds (maximum wait time for next data chunk)
+        .read_timeout(std::time::Duration::from_secs(60))
+        // Do not set overall timeout
+        .build()
+        .expect("Failed to build HTTP client");
+
+    // Send request
+    let response = client
+        .get(url)
+        .send()
+        .await
+        .expect("Failed to start CSPICE download");
+
+    // Check status code
+    if !response.status().is_success() {
+        panic!(
+            "Failed to download CSPICE: HTTP {} from {}",
+            response.status(),
+            url
+        );
+    }
+
+    // Get content size
+    let total_size = response.content_length();
+    if let Some(size) = total_size {
+        println!(
+            "Download size: {} bytes ({} MB)",
+            size,
+            size / (1024 * 1024)
+        );
+    }
+
+    // Streaming download
+    let mut file = std::fs::File::create(download_target).expect("Failed to create download file");
+
+    let mut downloaded = 0u64;
+    let mut stream = response.bytes_stream();
+
+    // Show initial progress
+    println!("Starting download from {}", url);
+    if let Some(total) = total_size {
+        println!("Progress: 0 MB / {} MB (0%)", total / (1024 * 1024));
+    }
+
+    while let Some(chunk_result) = stream.next().await {
+        let chunk = chunk_result.expect("Failed to read download chunk");
+
+        file.write_all(&chunk)
+            .expect("Failed to write to download file");
+
+        downloaded += chunk.len() as u64;
+
+        // Progress display (every 1MB)
+        if downloaded % (1024 * 1024) < chunk.len() as u64 {
+            if let Some(total) = total_size {
+                let percent = (downloaded as f64 / total as f64 * 100.0) as u32;
+                println!(
+                    "Progress: {} MB / {} MB ({}%)",
+                    downloaded / (1024 * 1024),
+                    total / (1024 * 1024),
+                    percent
+                );
+            } else {
+                println!("Downloaded {} MB", downloaded / (1024 * 1024));
+            }
+        }
+    }
+
+    file.flush().expect("Failed to flush download file");
+
+    // Verify download completion
+    if let Some(total) = total_size {
+        if downloaded != total {
+            panic!(
+                "Download incomplete: got {} bytes, expected {} bytes",
+                downloaded, total
+            );
+        }
+    }
+
+    downloaded
 }

--- a/cspice-sys/build.rs
+++ b/cspice-sys/build.rs
@@ -114,7 +114,7 @@ fn download_cspice(out_dir: &Path) {
 
     println!("Downloading from: {}", url);
 
-    // Tokioランタイムを作成して非同期ダウンロードを実行
+    // Create Tokio runtime and perform asynchronous download
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()


### PR DESCRIPTION
## Description
This PR fixes a issue where CSPICE downloads were failing due to inappropriate timeout configurations. The previous implementation could timeout on large files even when the download was progressing normally.
### Problem
The blocking download implementation had no proper timeout control, which could cause:

* Entire downloads to fail on slower connections even when data was actively being received
* No distinction between a stalled connection and a slow but active download
* Frustrating build failures for users with limited bandwidth

### Solution
Implemented async streaming download with read_timeout instead of an overall timeout:

read_timeout(60s): Maximum time to wait for the next chunk of data
connect_timeout(30s): Maximum time to establish initial connection
No overall timeout: Allows large downloads to complete on slow connections

Why read_timeout is crucial:
``` rust
// ❌ Bad: Overall timeout kills active downloads
.timeout(Duration::from_secs(300))  // 5 min total - fails on slow connections

// ✅ Good: Read timeout only triggers on stalled connections
.read_timeout(Duration::from_secs(60))  // Reset on each chunk received
```
This ensures the download only fails when the connection is genuinely stalled (no data for 60s), not when it's simply slow but making progress.

## Additional improvements:

* Progress display to show download is active
* Streaming to prevent memory issues
* Download verification for integrity